### PR TITLE
base-modalの閉じるボタンのstyle調整

### DIFF
--- a/src/components/layout/base-modal/style.module.css
+++ b/src/components/layout/base-modal/style.module.css
@@ -30,7 +30,8 @@
         transition: opacity 0.3s ease;
       }
 
-      @media (max-width: 1200px) {
+      /* 1312px = (max-width の1280px) + (body の左右のマージン 16px * 2) */
+      @media (max-width: 1312px) {
         right: 24px;
       }
 


### PR DESCRIPTION
画面幅1200px ~ 1300pxあたりで閉じるボタンが崩れてたのを直した

before
<img width="747" height="380" alt="image" src="https://github.com/user-attachments/assets/db738ac6-885a-402a-af66-9ed0066d8f3e" />
